### PR TITLE
[Core] Structured Output Refactor - Use backend parallelism, add new llguidance impl [2/n]

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -19,7 +19,7 @@ pillow  # Required for image processing
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.11.3
-llguidance >= 1.3.0, < 1.4.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "s390x" or platform_machine == "ppc64le"
+llguidance >= 1.5.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "s390x" or platform_machine == "ppc64le"
 outlines_core == 0.2.11
 # required for outlines backend disk cache
 diskcache == 5.6.3


### PR DESCRIPTION
## Purpose
Continuing the refactor, begin using the the backend's impl of fill_bitmasks_batch
Bumping llguidance version to 1.5.0 to begin support for accepting tokens in batch, which will be added in the next PR

## Test Plan
Unit tests for now

## Test Result
Pass


