### PR TITLE
[Core] Integrate batch processing in scheduler and GPU worker [3/N]

### DIFF
--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -8,27 +8,21 @@ import os
 import tempfile
 from typing import TYPE_CHECKING
 
-import numpy as np
 import regex as re
-import torch
 from cachetools import LRUCache
 from diskcache import Cache
 
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.utils.import_utils import LazyLoader
-from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 
 if TYPE_CHECKING:
     import outlines_core as oc
     import transformers.convert_slow_tokenizer as convert_slow_tokenizer
     import transformers.file_utils as file_utils
-    import xgrammar as xgr
 
     from vllm.tokenizers import TokenizerLike
-    from vllm.v1.worker.gpu_input_batch import InputBatch
 else:
-    xgr = LazyLoader("xgr", globals(), "xgrammar")
     oc = LazyLoader("oc", globals(), "outlines_core")
     file_utils = LazyLoader("file_utils", globals(), "transformers.file_utils")
     convert_slow_tokenizer = LazyLoader(
@@ -39,84 +33,6 @@ else:
 logger = init_logger(__name__)
 
 CACHE = None
-
-
-def apply_grammar_bitmask(
-    scheduler_output: SchedulerOutput,
-    grammar_output: GrammarOutput,
-    input_batch: InputBatch,
-    logits: torch.Tensor,
-) -> None:
-    """
-    Apply grammar bitmask to output logits of the model with xgrammar function.
-
-    Args:
-        scheduler_output (SchedulerOutput): The result of engine scheduling.
-        input_batch (InputBatch): The input of model runner.
-        logits (torch.Tensor): The output logits of model forward.
-    """
-    # Serialization of np.ndarray is much more efficient than a tensor,
-    # so we receive it in that format.
-    grammar_bitmask = grammar_output.grammar_bitmask
-
-    # We receive the structured output bitmask from the scheduler,
-    # compacted to contain bitmasks only for structured output requests.
-    # The order of the requests in the bitmask is not guaranteed to be the
-    # same as the order of the requests in the gpu runner's batch. We need
-    # to sort the bitmask to match the order of the requests used here.
-
-    # Get the batch indices of the structured output requests.
-    # Keep track of the number of speculative tokens scheduled for every
-    # request in the batch, as the logit indices are offset by this amount.
-    struct_out_req_batch_indices: dict[str, int] = {}
-    cumulative_offset = 0
-    spec_tokens = scheduler_output.scheduled_spec_decode_tokens
-    struct_out_req_ids = set(grammar_output.structured_output_request_ids)
-    for batch_index, req_id in enumerate(input_batch.req_ids):
-        logit_index = batch_index + cumulative_offset
-        cumulative_offset += len(spec_tokens.get(req_id, ()))
-        if req_id in struct_out_req_ids:
-            struct_out_req_batch_indices[req_id] = logit_index
-
-    out_indices = []
-
-    # Reorder the bitmask to match the order of the requests in the batch.
-    sorted_bitmask = np.full(
-        shape=(logits.shape[0], grammar_bitmask.shape[1]),
-        fill_value=-1,
-        dtype=grammar_bitmask.dtype,
-    )
-    cumulative_index = 0
-    for req_id in grammar_output.structured_output_request_ids:
-        num_spec_tokens = len(spec_tokens.get(req_id, ()))
-        if (logit_idx := struct_out_req_batch_indices.get(req_id)) is not None:
-            for i in range(1 + num_spec_tokens):
-                bitmask_index = logit_idx + i
-                sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
-                out_indices.append(bitmask_index)
-        cumulative_index += 1 + num_spec_tokens
-
-    # Copy async to device as tensor.
-    grammar_bitmask = torch.from_numpy(sorted_bitmask).to(
-        logits.device, non_blocking=True
-    )
-
-    # If the length of out indices and the logits have the same shape
-    # we don't need to pass indices to the kernel,
-    # since the bitmask is already aligned with the logits.
-    skip_out_indices = len(out_indices) == logits.shape[0]
-
-    index_tensor = None
-    if not skip_out_indices:
-        # xgrammar expects a python list of indices but it will actually work with
-        # a tensor. If we copy the tensor ourselves here we can do it in a non_blocking
-        # manner and there should be no cpu sync within xgrammar.
-        index_tensor = torch.tensor(
-            out_indices, dtype=torch.int32, device="cpu", pin_memory=True
-        )
-        index_tensor = index_tensor.to(logits.device, non_blocking=True)
-
-    xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, indices=index_tensor)
 
 
 class OutlinesVocabulary:

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import TYPE_CHECKING
+
 import numpy as np
 import torch
 
@@ -7,6 +9,104 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch
+
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu_model_runner import GrammarInputBuffers
+
+
+def apply_grammar_bitmask(
+    logits: torch.Tensor,
+    req_ids: list[str],
+    grammar_req_ids: list[str],
+    grammar_bitmask: np.ndarray,
+    input_buffers: GrammarInputBuffers,
+    scheduled_spec_decode_tokens: dict[str, list[int]] | None = None,
+) -> None:
+    """Apply grammar bitmask to logits using a Triton kernel.
+
+    Handles both regular decoding and speculative decoding. For speculative
+    decoding, the bitmask and logits have multiple consecutive entries per
+    request.
+
+    Args:
+        logits: Output logits tensor [num_logits, vocab_size]
+        req_ids: Request IDs in batch order (one per base logit position)
+        grammar_req_ids: Request IDs that have grammar constraints
+        grammar_bitmask: Bitmask array with consecutive entries per request
+        input_buffers: Pre-allocated GPU buffers
+        scheduled_spec_decode_tokens: Optional dict mapping req_id -> spec tokens
+    """
+    input_buffers.grammar_bitmask.np[: grammar_bitmask.shape[0]] = grammar_bitmask
+    input_buffers.grammar_bitmask.copy_to_gpu(grammar_bitmask.shape[0])
+
+    num_logits = logits.shape[0]
+
+    if scheduled_spec_decode_tokens:
+        # Speculative decoding: compute mapping accounting for multiple
+        # logit/bitmask positions per request
+        mapping = _compute_spec_decode_mapping(
+            req_ids, grammar_req_ids, scheduled_spec_decode_tokens
+        )
+    else:
+        # Simple case: 1:1 mapping between requests and logit positions
+        grammar_req_id_to_idx = {req_id: i for i, req_id in enumerate(grammar_req_ids)}
+        mapping = [grammar_req_id_to_idx.get(req_id, -1) for req_id in req_ids]
+
+    input_buffers.bitmask_indices.np[:num_logits] = mapping
+    input_buffers.bitmask_indices.copy_to_gpu(num_logits)
+
+    vocab_size = logits.shape[-1]
+    BLOCK_SIZE = 8192
+    grid = (num_logits, triton.cdiv(vocab_size, BLOCK_SIZE))
+    _apply_grammar_bitmask_kernel[grid](
+        logits,
+        logits.stride(0),
+        input_buffers.bitmask_indices.gpu[:num_logits],
+        input_buffers.grammar_bitmask.gpu,
+        input_buffers.grammar_bitmask.gpu.stride(0),
+        vocab_size,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def _compute_spec_decode_mapping(
+    req_ids: list[str],
+    grammar_req_ids: list[str],
+    scheduled_spec_decode_tokens: dict[str, list[int]],
+) -> list[int]:
+    """Compute logit -> bitmask index mapping for speculative decoding.
+
+    In speculative decoding:
+    - Logits are laid out as: [req0_pos0, req0_pos1, ..., req1_pos0, ...]
+    - Bitmask is laid out as: [grammar_req0_pos0, grammar_req0_pos1, ...]
+
+    Returns a list where mapping[logit_idx] = bitmask_idx (or -1 if no bitmask).
+    """
+    # Build bitmask base index for each grammar request
+    # (cumulative index accounting for num_positions per request)
+    grammar_req_to_bitmask_base: dict[str, int] = {}
+    cumulative_bitmask_idx = 0
+    for req_id in grammar_req_ids:
+        grammar_req_to_bitmask_base[req_id] = cumulative_bitmask_idx
+        num_spec_tokens = len(scheduled_spec_decode_tokens.get(req_id, []))
+        cumulative_bitmask_idx += 1 + num_spec_tokens
+
+    # Build mapping for each logit position
+    mapping: list[int] = []
+    for req_id in req_ids:
+        num_spec_tokens = len(scheduled_spec_decode_tokens.get(req_id, []))
+        num_positions = 1 + num_spec_tokens
+
+        if req_id in grammar_req_to_bitmask_base:
+            bitmask_base = grammar_req_to_bitmask_base[req_id]
+            for i in range(num_positions):
+                mapping.append(bitmask_base + i)
+        else:
+            # No grammar constraint for this request
+            for _ in range(num_positions):
+                mapping.append(-1)
+
+    return mapping
 
 
 class StructuredOutputsWorker:


### PR DESCRIPTION
## Purpose
Continuing the structured output refactor, moving on to scheduler and model runner.

- Added changes in the scheduler to support batch token acceptance and handle warning reporting
- Added a pre-allocated buffer for bitmasks, as tensor creation was taking a good deal of time at high batch sizes, taking into account speculative token counts
- Refactored the location of bitmask apply code to better separate cpu vs gpu paths

## Test Plan
Unit tests for now

## Test Result
Passed