### PR TITLE
[Core] Structured Output refactor, adding a cached llguidance backend to take advantage of matcher.deep_copy() [4/4]

### DIFF
--- a/tests/v1/structured_output/test_backend_cached_guidance.py
+++ b/tests/v1/structured_output/test_backend_cached_guidance.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from transformers import AutoTokenizer
+
+from vllm.config import StructuredOutputsConfig, VllmConfig
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.v1.structured_output.backend_cached_guidance import (
+    CachedGuidanceBackend,
+    _validate_grammar_impl,
+    validate_cached_guidance_grammar,
+)
+from vllm.v1.structured_output.backend_types import StructuredOutputOptions
+
+TOKENIZER = "gpt2"
+
+
+def test_cached_backend_compile_grammar_cache_hit():
+    """Test that compiling the same grammar twice uses the cache."""
+    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER)
+    vllm_config = VllmConfig(
+        decoding_config=StructuredOutputsConfig(backend="cached_guidance"),
+    )
+
+    # Clear the class-level cache before test
+    CachedGuidanceBackend._matcher_templates.clear()
+
+    backend = CachedGuidanceBackend(
+        vllm_config,
+        tokenizer=tokenizer,
+        vocab_size=50257,
+    )
+
+    schema = '{"type": "object"}'
+
+    # First compilation - cache miss
+    grammar1 = backend.compile_grammar(StructuredOutputOptions.JSON, schema)
+    assert len(CachedGuidanceBackend._matcher_templates) == 1
+
+    # Second compilation - cache hit (should not add to cache)
+    grammar2 = backend.compile_grammar(StructuredOutputOptions.JSON, schema)
+    assert len(CachedGuidanceBackend._matcher_templates) == 1
+
+    # Both grammars should be functional
+    assert not grammar1.is_terminated()
+    assert not grammar2.is_terminated()
+
+
+def test_cached_backend_compile_grammar_independence():
+    """Test that cached matchers are independent copies."""
+    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER)
+    vllm_config = VllmConfig(
+        decoding_config=StructuredOutputsConfig(backend="cached_guidance"),
+    )
+
+    # Clear the class-level cache before test
+    CachedGuidanceBackend._matcher_templates.clear()
+
+    backend = CachedGuidanceBackend(
+        vllm_config,
+        tokenizer=tokenizer,
+        vocab_size=50257,
+    )
+
+    schema = '{"type": "object"}'
+
+    # Get two grammars from the same schema
+    grammar1 = backend.compile_grammar(StructuredOutputOptions.JSON, schema)
+    grammar2 = backend.compile_grammar(StructuredOutputOptions.JSON, schema)
+
+    # Advance grammar1 to a different state
+    prompt = tokenizer.encode('{"a": "b"}')
+    for token in prompt:
+        grammar1.accept_tokens("", [token])
+    grammar1.accept_tokens("", [tokenizer.eos_token_id])
+
+    # grammar1 should be terminated, but grammar2 should not be affected
+    assert grammar1.is_terminated()
+    assert not grammar2.is_terminated()
+
+
+def test_validate_grammar_cached():
+    """Test that validate_cached_guidance_grammar uses lru_cache."""
+    # Clear the lru_cache before test
+    _validate_grammar_impl.cache_clear()
+
+    sampling_params = SamplingParams(
+        structured_outputs=StructuredOutputsParams(
+            json='{"type": "object"}',
+        ),
+    )
+
+    # First validation - cache miss
+    validate_cached_guidance_grammar(sampling_params)
+    cache_info_1 = _validate_grammar_impl.cache_info()
+    assert cache_info_1.misses == 1
+    assert cache_info_1.hits == 0
+
+    # Second validation - cache hit
+    validate_cached_guidance_grammar(sampling_params)
+    cache_info_2 = _validate_grammar_impl.cache_info()
+    assert cache_info_2.misses == 1
+    assert cache_info_2.hits == 1
+
+
+def test_cached_backend_different_schemas():
+    """Test that different schemas get separate cache entries."""
+    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER)
+    vllm_config = VllmConfig(
+        decoding_config=StructuredOutputsConfig(backend="cached_guidance"),
+    )
+
+    # Clear the class-level cache before test
+    CachedGuidanceBackend._matcher_templates.clear()
+
+    backend = CachedGuidanceBackend(
+        vllm_config,
+        tokenizer=tokenizer,
+        vocab_size=50257,
+    )
+
+    schema1 = '{"type": "object"}'
+    schema2 = '{"type": "string"}'
+    schema3 = '{"type": "number"}'
+
+    backend.compile_grammar(StructuredOutputOptions.JSON, schema1)
+    assert len(CachedGuidanceBackend._matcher_templates) == 1
+
+    backend.compile_grammar(StructuredOutputOptions.JSON, schema2)
+    assert len(CachedGuidanceBackend._matcher_templates) == 2
+
+    backend.compile_grammar(StructuredOutputOptions.JSON, schema3)
+    assert len(CachedGuidanceBackend._matcher_templates) == 3
+
+    # Reusing schema1 should not add new entry
+    backend.compile_grammar(StructuredOutputOptions.JSON, schema1)
+    assert len(CachedGuidanceBackend._matcher_templates) == 3

--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -11,7 +11,7 @@ from vllm.config.utils import config
 from vllm.utils.hashing import safe_hash
 
 StructuredOutputsBackend = Literal[
-    "auto", "xgrammar", "guidance", "outlines", "lm-format-enforcer"
+    "auto", "xgrammar", "guidance", "cached_guidance", "outlines", "lm-format-enforcer"
 ]
 
 

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -37,6 +37,9 @@ from vllm.utils import length_from_prompt_token_ids_or_embeds, random_uuid
 from vllm.utils.torch_utils import set_default_torch_num_threads
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.metrics.stats import MultiModalCacheStats
+from vllm.v1.structured_output.backend_cached_guidance import (
+    validate_cached_guidance_grammar,
+)
 from vllm.v1.structured_output.backend_guidance import (
     has_guidance_unsupported_json_features,
     validate_guidance_grammar,
@@ -362,6 +365,15 @@ class InputProcessor:
                     "backends or tokenizer_mode='hf' instead."
                 )
             validate_guidance_grammar(params, tokenizer=None)
+        elif backend == "cached_guidance":
+            # cached_guidance backend (like guidance but with LRU caching)
+            if isinstance(self.tokenizer, MistralTokenizer):
+                raise ValueError(
+                    "Mistral tokenizer is not supported for the 'cached_guidance' "
+                    "structured output backend. Please use ['xgrammar', 'outlines'] "
+                    "backends or tokenizer_mode='hf' instead."
+                )
+            validate_cached_guidance_grammar(params)
         elif backend == "outlines":
             # outlines backend
             validate_structured_output_request_outlines(params)

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -9,6 +9,7 @@ from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParserManager
 from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.utils.import_utils import LazyLoader
+from vllm.v1.structured_output.backend_cached_guidance import CachedGuidanceBackend
 from vllm.v1.structured_output.backend_guidance import GuidanceBackend
 from vllm.v1.structured_output.backend_types import (
     StructuredOutputBackend,
@@ -108,6 +109,12 @@ class StructuredOutputManager:
                 )
             elif backend == "guidance":
                 self.backend = GuidanceBackend(
+                    self.vllm_config,
+                    tokenizer=self.tokenizer,
+                    vocab_size=vocab_size,
+                )
+            elif backend == "cached_guidance":
+                self.backend = CachedGuidanceBackend(
                     self.vllm_config,
                     tokenizer=self.tokenizer,
                     vocab_size=vocab_size,

--- a/vllm/v1/structured_output/backend_cached_guidance.py
+++ b/vllm/v1/structured_output/backend_cached_guidance.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Cached LLGuidance backend with simplified caching using lru_cache and ClassVar.
+
+This module provides a cached version of the GuidanceBackend that:
+1. Caches grammar validation using @lru_cache
+2. Caches LLMatcher templates using a class-level dict
+3. Returns deep_copy() of cached matchers for each request
+
+When validation and compilation happen in the same process, the matcher
+created during validation is reused during compilation (cache hit).
+"""
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import TYPE_CHECKING, ClassVar
+
+from vllm.sampling_params import SamplingParams
+from vllm.utils.import_utils import LazyLoader
+from vllm.v1.structured_output.backend_guidance import (
+    GuidanceBackend,
+    GuidanceGrammar,
+    serialize_guidance_grammar,
+)
+from vllm.v1.structured_output.backend_types import (
+    StructuredOutputGrammar,
+    StructuredOutputOptions,
+)
+from vllm.v1.structured_output.request import get_structured_output_key
+
+if TYPE_CHECKING:
+    import llguidance
+
+else:
+    llguidance = LazyLoader("llguidance", globals(), "llguidance")
+
+
+@lru_cache(maxsize=64)
+def _validate_grammar_impl(tp: StructuredOutputOptions, grm: str) -> None:
+    """Validate grammar syntax (cached by raw key, not serialized).
+
+    Uses (tp, grm) as cache key to skip serialization on cache hit.
+    Raises ValueError on invalid grammar.
+    """
+    serialized_grammar = serialize_guidance_grammar(tp, grm)
+    err = llguidance.LLMatcher.validate_grammar(serialized_grammar, None)
+    if err:
+        raise ValueError(f"Grammar error: {err}")
+
+
+def validate_cached_guidance_grammar(sampling_params: SamplingParams) -> None:
+    """Validate grammar, skipping serialization for previously validated grammars."""
+    if sampling_params.structured_outputs is None:
+        return
+    tp, grm = get_structured_output_key(sampling_params.structured_outputs)
+    _validate_grammar_impl(tp, grm)  # raises on invalid, skips on cache hit
+
+
+@dataclass
+class CachedGuidanceBackend(GuidanceBackend):
+    """GuidanceBackend with grammar caching.
+
+    Uses a class-level cache to share LLMatcher templates across all instances.
+    Returns deep_copy() of cached matchers for independence.
+    """
+
+    # Class-level cache: (request_type, grammar_spec) -> template matcher
+    # Keyed on raw inputs to skip serialization on cache hit
+    _matcher_templates: ClassVar[
+        dict[tuple[StructuredOutputOptions, str], llguidance.LLMatcher]
+    ] = {}
+
+    def compile_grammar(
+        self, request_type: StructuredOutputOptions, grammar_spec: str
+    ) -> StructuredOutputGrammar:
+        cache_key = (request_type, grammar_spec)
+
+        if cache_key in self._matcher_templates:
+            # Cache hit: skip serialization, return deep copy
+            ll_matcher = self._matcher_templates[cache_key].deep_copy()
+        else:
+            # Cache miss: serialize and create matcher
+            serialized_grammar = serialize_guidance_grammar(
+                request_type,
+                grammar_spec,
+                self.disable_any_whitespace,
+                self.disable_additional_properties,
+            )
+            ll_matcher = llguidance.LLMatcher(
+                self.ll_tokenizer,
+                serialized_grammar,
+                log_level=int(os.environ.get("LLGUIDANCE_LOG_LEVEL", "1")),
+            )
+            # Cache a template copy
+            self._matcher_templates[cache_key] = ll_matcher.deep_copy()
+
+        grammar = GuidanceGrammar(
+            ll_matcher=ll_matcher,
+            ll_tokenizer=self.ll_tokenizer,
+            vocab_size=self.vocab_size,
+        )
+        grammar.check_error()
+        return grammar


### PR DESCRIPTION
## Purpose
As a final stacked PR, adding in a new backend for llguidance for situations where there is not much variance in llguidance grammars being used.

The cached implementation leverates .deep_copy() on the matches to create new instances without needing to re-init tokenizers or compile grammars.

Implementation generally tries to avoid serializing the grammar as it is a non-trivial amount of work compared to just hashing the input params. 

## Test Plan
Unit tests

Will add actual serving tests here, as this is the end of the stack of changes

## Test Result
Unit tests passed

